### PR TITLE
Any asset that is not accounted for will not load

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,12 @@
           </div>
         </li>
         <li>
+          If your site is using an appcache and makes a request for an asset that isn't accounted for in the manifest, the browser will fail to load the asset.
+          <div class="details">
+            <p>If expect to mix offline assets and online assets (like Google Analytics), you <strong>must</strong> include a <code>NETWORK</code> white list as described above.</p>
+          </div>
+        </li>
+        <li>
           Over SSL, all resources in the manifest must respect the same-origin policy.
           <div class="details">
             <p>That is, all paths must be relative, or point to resources on the same host and port as the current page.</p>


### PR DESCRIPTION
Just added a new fact about how browsers refuse to load any urls that aren't accounted for in the manifest in some way. Bit of a gotcha.
