### PR TITLE
Link to the article explaining "How to inhibit caching AppCache manifest?" has been added in the resources section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,6 +210,7 @@ CACHE
         <li>Safari Developer Library &ndash; <a href="http://developer.apple.com/library/safari/#documentation/appleapplications/reference/SafariWebContent/Client-SideStorage/Client-SideStorage.html">Storing Data on the Client</a></li>
         <li>Online validator, JSON(P) validation API, and TextMate bundle) &ndash; <a href="http://manifest-validator.com">Cache Manifest Validator</a></li>
         <li>A List Apart  &ndash; <a href="http://www.alistapart.com/articles/application-cache-is-a-douchebag/">Application Cache is a Douchebag</a></li>
+        <li>The4thDimension  &ndash; <a href="http://www.the4thdimension.net/2012/03/how-to-inhibit-caching-appcache.html">How to inhibit caching AppCache manifest?</a></li>
       </ul>
     </section>
 


### PR DESCRIPTION
There is a manifest file which specifies which files to be cached in the users browser. The scenario may get worse if the manifest file itself is cached at the users end. So its of utmost importance that user's browser always requests the manifest file to the server. I have listed 2 ways to force the user's browser to ensure that the manifest does not stay cached forever. Added the link of the blog in the resources section. Let me know if there are any errors/ typos or anything I can fix. 

 I hope this PR gets accepted, just want to give back to the community.
