### PR TITLE
Firefox 26+ doesn't ask the user

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@ CACHE
         <li>Regardless of whether you include the address of the current page in the manifest, it will be cached.</li>
         <li>In Chrome, you can see information about appcached sites by visiting <code>chrome://appcache-internals/</code>. This allows you to see which sites have appcached, when they were last modified, and how much space they're using. You can also remove appcaches here.</li>
         <li>In Firefox, any resources served with <code>Cache-control: <strong>no-store</strong></code> will not be cached, even if they're explicitly included in the manifest.</li>
-        <li>Firefox will always ask the user for permission before caching a site for the first time.</li>
+        <li>Firefox version 25 and below will always ask the user for permission before caching a site for the first time.</li>
       </ul>
     </section>
 


### PR DESCRIPTION
Starting with Firefox 26, the user isn't prompted when a website uses an appcache.
